### PR TITLE
Fix rewriting of try-finally blocks containing throw statements

### DIFF
--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -1019,7 +1019,7 @@ object Sandbox {
 
             override fun visitTryCatchBlock(start: Label, end: Label, handler: Label, type: String?) {
                 currentTryCatchBlockPosition++
-                if (currentTryCatchBlockPosition in badTryCatchBlockPositions) {
+                if (start == handler) {
                     /*
                      * For unclear reasons, the Java compiler sometimes emits exception table entries that catch any
                      * exception and transfer control to the inside of the same block. This produces an infinite loop
@@ -1045,7 +1045,14 @@ object Sandbox {
                         labelsToRewrite.add(handler)
                     }
                 }
-                super.visitTryCatchBlock(start, end, handler, type)
+                /*
+                 * For unclear reasons, the Java compiler *also* sometimes emits exception table entries that cover
+                 * a larger region than necessary and partially overlap the handler, especially with throw statements
+                 * inside try-finally blocks. These entries do have functional significance, but must have their
+                 * protected regions shortened to avoid an infinite loop.
+                 */
+                val safeEnd = if (currentTryCatchBlockPosition in badTryCatchBlockPositions) handler else end
+                super.visitTryCatchBlock(start, safeEnd, handler, type)
             }
 
             private var nextLabel: Label? = null

--- a/core/src/test/kotlin/sandbox/TestByteCodeRewriters.kt
+++ b/core/src/test/kotlin/sandbox/TestByteCodeRewriters.kt
@@ -235,6 +235,53 @@ try {
         executionResult shouldNot haveCompleted()
         executionResult.threw should beInstanceOf(Error::class)
     }
+    "should correctly handle throw inside try-catch" {
+        val executionResult = Source.fromSnippet(
+            """
+try {
+    System.out.println("Try");
+    throw new RuntimeException("Boom");
+} catch (Exception e) {
+    System.out.println(e.getMessage());
+}
+            """.trim()
+        ).compile().execute()
+
+        executionResult should haveCompleted()
+        executionResult should haveOutput("Try\nBoom")
+    }
+    "should correctly handle throw inside try-finally" {
+        val executionResult = Source.fromSnippet(
+            """
+try {
+    System.out.println("Try");
+    throw new RuntimeException("Boom");
+} finally {
+    System.out.println("Finally");
+}
+            """.trim()
+        ).compile().execute()
+
+        executionResult shouldNot haveCompleted()
+        executionResult should haveOutput("Try\nFinally")
+        executionResult.threw should beInstanceOf<RuntimeException>()
+    }
+    "should correctly handle throwing a dangerous exception inside try-finally" {
+        val executionResult = Source.fromSnippet(
+            """
+try {
+    System.out.println("Try");
+    throw new Error("Boom");
+} finally {
+    System.out.println("Finally");
+}
+            """.trim()
+        ).compile().execute()
+
+        executionResult shouldNot haveCompleted()
+        executionResult should haveOutput("Try")
+        executionResult.threw should beInstanceOf<Error>()
+    }
     "should remove finalizers" {
         val executionResult = Source.fromSnippet(
             """

--- a/core/src/test/kotlin/sandbox/TestByteCodeRewriters.kt
+++ b/core/src/test/kotlin/sandbox/TestByteCodeRewriters.kt
@@ -266,6 +266,26 @@ try {
         executionResult should haveOutput("Try\nFinally")
         executionResult.threw should beInstanceOf<RuntimeException>()
     }
+    "should correctly handle throw inside try-catch-finally" {
+        val executionResult = Source.fromSnippet(
+            """
+try {
+    System.out.println("Try");
+    throw new RuntimeException("Boom");
+} catch (Exception e) {
+    System.out.println("Catch");
+    throw new RuntimeException("Bang");
+} finally {
+    System.out.println("Finally");
+}
+            """.trim()
+        ).compile().execute()
+
+        executionResult shouldNot haveCompleted()
+        executionResult should haveOutput("Try\nCatch\nFinally")
+        executionResult.threw should beInstanceOf<RuntimeException>()
+        executionResult.threw!!.message shouldBe "Bang"
+    }
     "should correctly handle throwing a dangerous exception inside try-finally" {
         val executionResult = Source.fromSnippet(
             """
@@ -280,6 +300,25 @@ try {
 
         executionResult shouldNot haveCompleted()
         executionResult should haveOutput("Try")
+        executionResult.threw should beInstanceOf<Error>()
+    }
+    "should correctly handle throwing a dangerous exception inside try-catch-finally" {
+        val executionResult = Source.fromSnippet(
+            """
+try {
+    System.out.println("Try");
+    throw new RuntimeException("Boom");
+} catch (Exception e) {
+    System.out.println("Catch");
+    throw new Error("Bang");
+} finally {
+    System.out.println("Finally");
+}
+            """.trim()
+        ).compile().execute()
+
+        executionResult shouldNot haveCompleted()
+        executionResult should haveOutput("Try\nCatch")
         executionResult.threw should beInstanceOf<Error>()
     }
     "should remove finalizers" {


### PR DESCRIPTION
This snippet of code should print "Finally" before failing with an exception:

```java
try {
  throw new RuntimeException();
} finally {
  System.out.println("Finally");
}
```

After transformation by the Jeed sandbox, however, it only fails; the finally block is not entered. This happens because the exception table entry emitted by the Java compiler for the try-finally construct protects the first instruction of the handler (finally block) in addition to the contents of the try block, i.e. the start of the handler is slightly inside the protected region. This causes the exception table preinspection to flag the exception table entry as bad, so the bytecode rewriting process removes the protection entirely.

This PR makes such exception table entries shortened instead of deleted, still avoiding the infinite loop that would otherwise result from propagation of forbidden exceptions.