### PR TITLE
Add line tracing plugin (and other adjustments)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ hs_err_*.log
 .idea/**/dictionaries
 .idea/**/shelf
 .idea/**/checkstyle-idea.xml
+**/test/kotlin/Scratch.kt
 
 # Generated files
 .idea/**/contentModel.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-output/
 *.swo
 *.iml
 hs_err_*.log
+.kotlintest/
 
 # User-specific stuff
 .idea/**/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-output/
 *.swp
 *.swo
 *.iml
+hs_err_*.log
 
 # User-specific stuff
 .idea/**/workspace.xml

--- a/core/src/main/kotlin/Compile.kt
+++ b/core/src/main/kotlin/Compile.kt
@@ -252,6 +252,10 @@ fun pathToClassName(path: String): String {
     return path.removeSuffix(".class").replace("/", ".")
 }
 
+fun binaryNameToClassName(binaryClassName: String): String {
+    return binaryClassName.replace('/', '.').replace('$', '.')
+}
+
 class JeedFileManager(private val parentFileManager: JavaFileManager) :
     ForwardingJavaFileManager<JavaFileManager>(parentFileManager) {
     val classFiles: MutableMap<String, JavaFileObject> = mutableMapOf()

--- a/core/src/main/kotlin/Execute.kt
+++ b/core/src/main/kotlin/Execute.kt
@@ -21,7 +21,8 @@ class SourceExecutionArguments(
     val dryRun: Boolean = false,
     waitForShutdown: Boolean = DEFAULT_WAIT_FOR_SHUTDOWN,
     @Transient
-    var methodToRun: Method? = null
+    var methodToRun: Method? = null,
+    val plugins: List<SandboxPlugin<*>> = listOf()
 ) : Sandbox.ExecutionArguments(
     timeout,
     permissions.union(REQUIRED_PERMISSIONS),
@@ -96,7 +97,7 @@ suspend fun CompiledSource.execute(
     executionArguments: SourceExecutionArguments = SourceExecutionArguments()
 ): Sandbox.TaskResults<out Any?> {
     val actualArguments = updateExecutionArguments(executionArguments)
-    return Sandbox.execute(classLoader, actualArguments) sandbox@{ (classLoader) ->
+    return Sandbox.execute(classLoader, actualArguments, actualArguments.plugins) sandbox@{ (classLoader) ->
         if (actualArguments.dryRun) {
             return@sandbox null
         }

--- a/core/src/main/kotlin/Execute.kt
+++ b/core/src/main/kotlin/Execute.kt
@@ -23,7 +23,7 @@ class SourceExecutionArguments(
     @Transient
     var methodToRun: Method? = null,
     @Transient
-    internal val plugins: MutableList<SandboxPlugin<*>> = mutableListOf()
+    internal val plugins: MutableList<ConfiguredSandboxPlugin<*, *>> = mutableListOf()
 ) : Sandbox.ExecutionArguments(
     timeout,
     permissions.union(REQUIRED_PERMISSIONS),
@@ -51,9 +51,19 @@ class SourceExecutionArguments(
         )
     }
 
-    fun addPlugin(plugin: SandboxPlugin<*>): SourceExecutionArguments {
-        plugins.add(plugin)
+    fun addPlugin(plugin: SandboxPlugin<Unit, *>): SourceExecutionArguments {
+        plugins.add(ConfiguredSandboxPlugin(plugin, Unit))
         return this
+    }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun <A : Any> addPlugin(plugin: SandboxPlugin<A, *>, arguments: A): SourceExecutionArguments {
+        plugins.add(ConfiguredSandboxPlugin(plugin, arguments))
+        return this
+    }
+
+    fun <A : Any> addPlugin(plugin: SandboxPluginWithDefaultArguments<A, *>): SourceExecutionArguments {
+        return addPlugin(plugin, plugin.createDefaultArguments())
     }
 }
 

--- a/core/src/main/kotlin/Execute.kt
+++ b/core/src/main/kotlin/Execute.kt
@@ -22,7 +22,8 @@ class SourceExecutionArguments(
     waitForShutdown: Boolean = DEFAULT_WAIT_FOR_SHUTDOWN,
     @Transient
     var methodToRun: Method? = null,
-    val plugins: List<SandboxPlugin<*>> = listOf()
+    @Transient
+    internal val plugins: MutableList<SandboxPlugin<*>> = mutableListOf()
 ) : Sandbox.ExecutionArguments(
     timeout,
     permissions.union(REQUIRED_PERMISSIONS),
@@ -48,6 +49,11 @@ class SourceExecutionArguments(
             // ClassLoader enumeration is probably not unsafe...
             RuntimePermission("getClassLoader"),
         )
+    }
+
+    fun addPlugin(plugin: SandboxPlugin<*>): SourceExecutionArguments {
+        plugins.add(plugin)
+        return this
     }
 }
 

--- a/core/src/main/kotlin/Jacoco.kt
+++ b/core/src/main/kotlin/Jacoco.kt
@@ -94,7 +94,6 @@ object IsolatedJacocoRuntime : IRuntime {
 }
 
 @Throws(ExecutionFailed::class)
-@Suppress("ReturnCount")
 suspend fun CompiledSource.jacoco(
     executionArguments: SourceExecutionArguments = SourceExecutionArguments()
 ): Pair<Sandbox.TaskResults<out Any?>, CoverageBuilder> {

--- a/core/src/main/kotlin/Jacoco.kt
+++ b/core/src/main/kotlin/Jacoco.kt
@@ -87,7 +87,7 @@ object IsolatedJacocoRuntime : IRuntime {
     object RuntimeDataAccessor {
         @JvmStatic
         fun get(): Any {
-            val workingData: JacocoWorkingData = Sandbox.confinedTaskWorkingData(Jacoco)
+            val workingData: JacocoWorkingData = Sandbox.CurrentTask.getWorkingData(Jacoco)
             return workingData.runtimeData
         }
     }

--- a/core/src/main/kotlin/Jacoco.kt
+++ b/core/src/main/kotlin/Jacoco.kt
@@ -12,6 +12,7 @@ import org.jacoco.core.runtime.RuntimeData
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import java.lang.reflect.InvocationTargetException
+import java.util.UUID
 
 @Throws(ExecutionFailed::class)
 @Suppress("ReturnCount")
@@ -67,7 +68,7 @@ suspend fun CompiledSource.jacoco(
 }
 
 class EmptyRuntime : AbstractRuntime() {
-    private val key = Integer.toHexString(hashCode())
+    private val key = UUID.randomUUID().toString()
 
     @Suppress("SpellCheckingInspection")
     override fun generateDataAccessor(classid: Long, classname: String, probecount: Int, mv: MethodVisitor): Int {
@@ -90,7 +91,6 @@ class EmptyRuntime : AbstractRuntime() {
 
     override fun shutdown() {
         remove(key)
-        return
     }
 
     companion object {

--- a/core/src/main/kotlin/LineTrace.kt
+++ b/core/src/main/kotlin/LineTrace.kt
@@ -75,7 +75,7 @@ object LineTrace : SandboxPlugin<LineTraceResult> {
         }
     }
 
-    override fun transformBeforeSandbox(bytecode: ByteArray, instrumentationData: Any?, context: RewritingContext): ByteArray {
+    override fun transformBeforeSandbox(bytecode: ByteArray, name: String, instrumentationData: Any?, context: RewritingContext): ByteArray {
         if (context != RewritingContext.UNTRUSTED) return bytecode
         val classReader = ClassReader(bytecode)
         val preinspectingClassVisitor = PreinspectingClassVisitor()

--- a/core/src/main/kotlin/LineTrace.kt
+++ b/core/src/main/kotlin/LineTrace.kt
@@ -1,0 +1,242 @@
+package edu.illinois.cs.cs125.jeed.core
+
+import com.squareup.moshi.JsonClass
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Handle
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import kotlin.reflect.jvm.javaMethod
+
+@Suppress("UNCHECKED_CAST")
+object LineTrace : SandboxPlugin<LineTraceResult> {
+    private const val TRACING_STACK_ITEMS = 2
+    private val tracingClassName = classNameToPath(TracingSink::class.java.name)
+    private val tracingLineMethodName = TracingSink::enterLine.javaMethod?.name ?: error("missing tracing method name")
+    private val tracingLineMethodDesc = Type.getMethodDescriptor(TracingSink::enterLine.javaMethod)
+
+    override fun createInitialData(): Any {
+        return mutableListOf<LineTraceResult.LineStep>()
+    }
+
+    override fun createFinalData(workingData: Any?): LineTraceResult {
+        return LineTraceResult(workingData as List<LineTraceResult.LineStep>)
+    }
+
+    override val requiredClasses: Set<Class<*>>
+        get() = setOf(TracingSink::class.java)
+
+    object TracingSink {
+        @JvmStatic
+        fun enterLine(file: String, line: Int) {
+            val data: MutableList<LineTraceResult.LineStep> = Sandbox.confinedTaskWorkingData(LineTrace)
+            data.add(LineTraceResult.LineStep(file, line))
+        }
+    }
+
+    override fun transformBeforeSandbox(bytecode: ByteArray, context: RewritingContext): ByteArray {
+        if (context != RewritingContext.UNTRUSTED) return bytecode
+        val classReader = ClassReader(bytecode)
+        val preinspectingClassVisitor = PreinspectingClassVisitor()
+        classReader.accept(preinspectingClassVisitor, 0)
+        val preinspection = preinspectingClassVisitor.getPreinspection()
+        if (preinspection.sourceFile == null) return bytecode
+        val classWriter = ClassWriter(classReader, 0)
+        val rewritingVisitor = TracingClassVisitor(classWriter, preinspection)
+        classReader.accept(rewritingVisitor, 0)
+        return classWriter.toByteArray()
+    }
+
+    private data class ClassPreinspection(
+        val sourceFile: String?,
+        val methodPreinspections: Map<MethodId, Map<Int, LabelInfo>>
+    )
+    private data class MethodId(val name: String, val descriptor: String)
+    private data class LabelInfo(val line: Int, var waitForFrame: Boolean)
+
+    private class PreinspectingClassVisitor : ClassVisitor(Opcodes.ASM9) {
+        private var sourceFile: String? = null
+        private val inspectedMethods = mutableMapOf<MethodId, Map<Int, LabelInfo>>()
+
+        override fun visitSource(source: String?, debug: String?) {
+            sourceFile = source
+        }
+
+        override fun visitMethod(
+            access: Int,
+            name: String,
+            descriptor: String,
+            signature: String?,
+            exceptions: Array<out String>?
+        ): MethodVisitor {
+            val labelLines = mutableMapOf<Int, LabelInfo>()
+            inspectedMethods[MethodId(name, descriptor)] = labelLines
+            return PreinspectingMethodVisitor(labelLines)
+        }
+
+        private class PreinspectingMethodVisitor(
+            val labelLines: MutableMap<Int, LabelInfo>
+        ) : MethodVisitor(Opcodes.ASM9) {
+            private val labelIndexes = mutableMapOf<Label, Int>()
+            private val needsFrame = mutableMapOf<Label, Boolean>()
+            private var mightNeedFrame: Label? = null
+            override fun visitLabel(label: Label) {
+                labelIndexes[label] = labelIndexes.size
+                needsFrame[label] = false
+                mightNeedFrame = label
+            }
+            override fun visitLineNumber(line: Int, start: Label) {
+                val index = labelIndexes[start] ?: error("must have visited the line label")
+                labelLines[index] = LabelInfo(line, false)
+            }
+            override fun visitFrame(
+                type: Int,
+                numLocal: Int,
+                local: Array<out Any>?,
+                numStack: Int,
+                stack: Array<out Any>?
+            ) {
+                mightNeedFrame?.let { needsFrame[it] = true } // If it's still pending, no insn was visited
+                mightNeedFrame = null
+            }
+            override fun visitEnd() {
+                needsFrame.forEach { (label, wait) ->
+                    labelLines[labelIndexes[label]]?.let { it.waitForFrame = wait }
+                }
+            }
+            override fun visitFieldInsn(opcode: Int, owner: String?, name: String?, descriptor: String?) {
+                mightNeedFrame = null
+            }
+            override fun visitIincInsn(`var`: Int, increment: Int) {
+                mightNeedFrame = null
+            }
+            override fun visitInsn(opcode: Int) {
+                mightNeedFrame = null
+            }
+            override fun visitIntInsn(opcode: Int, operand: Int) {
+                mightNeedFrame = null
+            }
+            override fun visitInvokeDynamicInsn(
+                name: String?,
+                descriptor: String?,
+                bootstrapMethodHandle: Handle?,
+                vararg bootstrapMethodArguments: Any?
+            ) {
+                mightNeedFrame = null
+            }
+            override fun visitJumpInsn(opcode: Int, label: Label?) {
+                mightNeedFrame = null
+            }
+            override fun visitLdcInsn(value: Any?) {
+                mightNeedFrame = null
+            }
+            override fun visitLookupSwitchInsn(dflt: Label?, keys: IntArray?, labels: Array<out Label>?) {
+                mightNeedFrame = null
+            }
+            override fun visitMethodInsn(
+                opcode: Int,
+                owner: String?,
+                name: String?,
+                descriptor: String?,
+                isInterface: Boolean
+            ) {
+                mightNeedFrame = null
+            }
+            override fun visitMultiANewArrayInsn(descriptor: String?, numDimensions: Int) {
+                mightNeedFrame = null
+            }
+            override fun visitTableSwitchInsn(min: Int, max: Int, dflt: Label?, vararg labels: Label?) {
+                mightNeedFrame = null
+            }
+            override fun visitTypeInsn(opcode: Int, type: String?) {
+                mightNeedFrame = null
+            }
+            override fun visitVarInsn(opcode: Int, `var`: Int) {
+                mightNeedFrame = null
+            }
+        }
+
+        fun getPreinspection(): ClassPreinspection {
+            return ClassPreinspection(sourceFile, inspectedMethods)
+        }
+    }
+
+    private class TracingClassVisitor(
+        visitor: ClassVisitor,
+        private val preinspection: ClassPreinspection
+    ) : ClassVisitor(Opcodes.ASM9, visitor) {
+        override fun visitMethod(
+            access: Int,
+            name: String,
+            descriptor: String,
+            signature: String?,
+            exceptions: Array<out String>?
+        ): MethodVisitor {
+            return TracingMethodVisitor(
+                super.visitMethod(access, name, descriptor, signature, exceptions),
+                preinspection.sourceFile ?: error("should only trace a class with a source file"),
+                preinspection.methodPreinspections[MethodId(name, descriptor)] ?: error("missing preinspection")
+            )
+        }
+    }
+
+    private class TracingMethodVisitor(
+        visitor: MethodVisitor,
+        private val sourceFile: String,
+        private val labelLines: Map<Int, LabelInfo>
+    ) : MethodVisitor(Opcodes.ASM9, visitor) {
+        private var currentLabelIndex = 0
+        private var waitingForFrameLine: Int? = null
+
+        override fun visitLabel(label: Label?) {
+            super.visitLabel(label)
+            labelLines[currentLabelIndex]?.let { labelInfo ->
+                if (labelInfo.waitForFrame) {
+                    waitingForFrameLine = labelInfo.line
+                } else {
+                    addTraceCall(labelInfo.line)
+                }
+            }
+            currentLabelIndex++
+        }
+
+        override fun visitFrame(
+            type: Int,
+            numLocal: Int,
+            local: Array<out Any>?,
+            numStack: Int,
+            stack: Array<out Any>?
+        ) {
+            super.visitFrame(type, numLocal, local, numStack, stack)
+            waitingForFrameLine?.let {
+                addTraceCall(it)
+            }
+            waitingForFrameLine = null
+        }
+
+        override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+            super.visitMaxs(maxStack + TRACING_STACK_ITEMS, maxLocals)
+        }
+
+        private fun addTraceCall(line: Int) {
+            visitLdcInsn(sourceFile)
+            visitLdcInsn(line)
+            visitMethodInsn(
+                Opcodes.INVOKESTATIC,
+                tracingClassName,
+                tracingLineMethodName,
+                tracingLineMethodDesc,
+                false
+            )
+        }
+    }
+}
+
+@JsonClass(generateAdapter = true)
+data class LineTraceResult(val steps: List<LineStep>) {
+    @JsonClass(generateAdapter = true)
+    data class LineStep(val source: String, val line: Int)
+}

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -1302,6 +1302,7 @@ object Sandbox {
             if (threadGroup != Thread.currentThread().threadGroup) {
                 confinedTask.addPermissionRequest(RuntimePermission("changeThreadGroup"), false)
             } else {
+                checkThreadLimits(confinedTask)
                 systemSecurityManager?.checkAccess(threadGroup)
             }
         }
@@ -1311,6 +1312,11 @@ object Sandbox {
             val threadGroup = Thread.currentThread().threadGroup
             val confinedTask = confinedTaskByThreadGroup()
                 ?: return systemSecurityManager?.threadGroup ?: return threadGroup
+            checkThreadLimits(confinedTask)
+            return systemSecurityManager?.threadGroup ?: threadGroup
+        }
+
+        private fun checkThreadLimits(confinedTask: ConfinedTask<*>) {
             if (confinedTask.shuttingDown) {
                 confinedTask.permissionRequests.add(
                     TaskResults.PermissionRequest(
@@ -1328,8 +1334,6 @@ object Sandbox {
                     )
                 )
                 throw SecurityException()
-            } else {
-                return systemSecurityManager?.threadGroup ?: threadGroup
             }
         }
 

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -89,13 +89,17 @@ object Sandbox {
             val DEFAULT_BLACKLISTED_CLASSES = setOf("java.lang.reflect.")
             val DEFAULT_UNSAFE_EXCEPTIONS = setOf<String>()
             val DEFAULT_ISOLATED_CLASSES = setOf<String>()
-            val DEFAULT_BLACKLISTED_METHODS = setOf(MethodFilter("java.lang.invoke.MethodHandles.Lookup", ""))
-            val PERMANENTLY_BLACKLISTED_CLASSES =
-                setOf(
-                    "edu.illinois.cs.cs125.jeed.",
-                    "org.objectweb.asm.",
-                    "java.lang.invoke.MethodHandles"
-                )
+            val DEFAULT_BLACKLISTED_METHODS = setOf(
+                MethodFilter("java.lang.invoke.MethodHandles.Lookup", ""),
+                MethodFilter("java.lang.reflect.", "setAccessible")
+            )
+            val PERMANENTLY_BLACKLISTED_CLASSES = setOf(
+                "edu.illinois.cs.cs125.jeed.",
+                "org.objectweb.asm.",
+                "com.sun.",
+                "net.bytebuddy.agent.",
+                "java.lang.invoke.MethodHandles"
+            )
             val ALWAYS_UNSAFE_EXCEPTIONS = setOf("java.lang.Error")
             val ALWAYS_ISOLATED_CLASSES = setOf("kotlin.coroutines.", "kotlinx.coroutines.")
             val COROUTINE_REQUIRED_CLASSES = setOf("java.lang.reflect.Constructor")

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -621,8 +621,8 @@ object Sandbox {
             }
         }
 
-        confinedTask.pluginData.forEach { (plugin, _) ->
-            plugin.executionFinished()
+        confinedTask.pluginData.forEach { (plugin, data) ->
+            plugin.executionFinished(data)
         }
 
         confinedTasks.remove(threadGroup)
@@ -1758,8 +1758,8 @@ interface SandboxPlugin<A : Any, V : Any> {
     fun transformBeforeSandbox(bytecode: ByteArray, name: String, instrumentationData: Any?, context: RewritingContext): ByteArray = bytecode
     fun transformAfterSandbox(bytecode: ByteArray, name: String, instrumentationData: Any?, context: RewritingContext): ByteArray = bytecode
     fun createInitialData(instrumentationData: Any?): Any?
+    fun executionFinished(workingData: Any?) { }
     fun createFinalData(workingData: Any?): V
-    fun executionFinished() { }
     val requiredClasses: Set<Class<*>>
         get() = setOf()
 }

--- a/core/src/main/kotlin/Snippet.kt
+++ b/core/src/main/kotlin/Snippet.kt
@@ -50,7 +50,9 @@ class Snippet(
 
     companion object {
         fun mapLocation(input: SourceLocation, remappedLineMapping: Map<Int, RemappedLine>): SourceLocation {
-            check(input.source == SNIPPET_SOURCE) { "Incorrect input source: ${input.source}" }
+            if (input.source != SNIPPET_SOURCE) {
+                return input
+            }
             val remappedLineInfo = remappedLineMapping[input.line]
                 ?: throw SourceMappingException(
                     "can't remap line ${input.line}: ${

--- a/core/src/test/kotlin/TestCoroutines.kt
+++ b/core/src/test/kotlin/TestCoroutines.kt
@@ -156,7 +156,7 @@ fun main() {
                 """.trimIndent()
             )
         ).kompile()
-        val executionArguments = SourceExecutionArguments(waitForShutdown = true)
+        val executionArguments = SourceExecutionArguments(waitForShutdown = true, timeout = 2000)
         repeat(16) { // Flaky
             val executionResult = kompileResult.execute(executionArguments = executionArguments)
             executionResult shouldNot haveTimedOut()

--- a/core/src/test/kotlin/TestExecute.kt
+++ b/core/src/test/kotlin/TestExecute.kt
@@ -592,6 +592,16 @@ fun haveTimedOut() = object : Matcher<Sandbox.TaskResults<out Any?>> {
     }
 }
 
+fun haveBeenKilled() = object : Matcher<Sandbox.TaskResults<out Any?>> {
+    override fun test(value: Sandbox.TaskResults<out Any?>): MatcherResult {
+        return MatcherResult(
+            value.killReason != null,
+            { "Task should have been killed" },
+            { "Task should not have been killed" }
+        )
+    }
+}
+
 fun haveOutput(output: String = "") = object : Matcher<Sandbox.TaskResults<out Any?>> {
     override fun test(value: Sandbox.TaskResults<out Any?>): MatcherResult {
         val actualOutput = value.output.trim()

--- a/core/src/test/kotlin/TestJacoco.kt
+++ b/core/src/test/kotlin/TestJacoco.kt
@@ -4,9 +4,11 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
 
 class TestJacoco : StringSpec({
-    "it should calculate coverage properly" {
+    "it should calculate full coverage properly" {
         Source.fromJava(
             """
 public class Test {
@@ -34,7 +36,34 @@ public class Main {
             testCoverage.lineCounter.coveredCount shouldBe 6
         }
     }
-    "f: it should allow class enumeration in the sandbox" {
+    "it should detect uncovered code" {
+        Source.fromJava(
+            """
+public class Test {
+  private int value;
+  public Test() {
+    value = 10;
+  }
+  public Test(int setValue) {
+    value = setValue;
+  }
+}
+public class Main {
+  public static void main() {
+    Test test = new Test(10);
+    System.out.println("Hmm");
+  }
+}""".trim()
+        ).compile().jacoco().also { (taskResults, coverage) ->
+            taskResults.completed shouldBe true
+            taskResults.permissionDenied shouldNotBe true
+
+            val testCoverage = coverage.classes.find { it.name == "Test" }!!
+            testCoverage.lineCounter.missedCount shouldNotBe 0
+            testCoverage.lineCounter.coveredCount shouldBe 3
+        }
+    }
+    "it should allow class enumeration in the sandbox" {
         val source = Source.fromJava(
             """
 public class Main {
@@ -51,6 +80,22 @@ public class Main {
         source.jacoco().also { (it) ->
             it should haveCompleted()
             it should haveOutput("2")
+        }
+    }
+    "it should not allow hijacking jacocoInit" {
+        val source = Source.fromJava(
+            """
+import java.lang.invoke.MethodHandles;
+public class Main {
+  private static void ${"$"}jacocoInit(MethodHandles.Lookup lookup, String name, Class type) {
+    // do something with the lookup?
+  }
+  public static void main() { }
+}""".trim()
+        ).compile()
+        assertThrows<IOException> {
+            // Jacoco refuses to re-instrument, which is good
+            source.jacoco()
         }
     }
 })

--- a/core/src/test/kotlin/TestLineTrace.kt
+++ b/core/src/test/kotlin/TestLineTrace.kt
@@ -4,7 +4,9 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveAtMostSize
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -129,6 +131,33 @@ public class Main {
         trace.steps.filter { it.line == 8 }.size shouldBe 2
     }
 
+    "should trace a try-catch-finally block" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    try {
+      System.out.println("Try");
+      String s = null;
+      s.toString();
+      System.out.println("Hmm");
+    } catch (Exception e) {
+      System.out.println("Catch");
+    } finally {
+      System.out.println("Finally");
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("Try\nCatch\nFinally")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.line == 4 }.size shouldBe 1
+        trace.steps.filter { it.line == 7 }.size shouldBe 0
+        trace.steps.filter { it.line == 9 }.size shouldBe 1
+        trace.steps.filter { it.line == 11 }.size shouldBe 1
+    }
+
     "should trace multiple functions" {
         val result = Source.fromJava(
             """
@@ -153,5 +182,223 @@ public class Main {
         trace.steps.filter { it.line == 6 }.size shouldBe 1
         trace.steps.filter { it.line == 9 }.size shouldBe 10
         trace.steps.filter { it.line == 10 }.size shouldBe 5
+    }
+
+    "should trace multiple classes" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    for (int i = 0; i < 10; i++) {
+      ShowIfOdd.showIfOdd(i);
+    }
+    System.out.println("Done");
+  }
+}
+public class ShowIfOdd {
+  public static void showIfOdd(int i) {
+    if (i % 2 != 0) {
+      System.out.println(i);
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("1\n3\n5\n7\n9\nDone")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.line == 4 }.size shouldBe 10
+        trace.steps.filter { it.line == 6 }.size shouldBe 1
+        trace.steps.filter { it.line == 11 }.size shouldBe 10
+        trace.steps.filter { it.line == 12 }.size shouldBe 5
+    }
+
+    "should trace multiple files" {
+        val result = Source(
+            mapOf(
+                "Main.java" to """
+public class Main {
+  public static void main() {
+    for (int i = 0; i < 10; i++) {
+      ShowIfOdd.showIfOdd(i);
+    }
+    System.out.println("Done");
+  }
+}""".trim(),
+                "ShowIfOdd.java" to """
+public class ShowIfOdd {
+  public static void showIfOdd(int i) {
+    if (i % 2 != 0) {
+      System.out.println(i);
+    }
+  }
+}""".trim()
+            )
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("1\n3\n5\n7\n9\nDone")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.source == "Main.java" && it.line == 4 }.size shouldBe 10
+        trace.steps.filter { it.source == "Main.java" && it.line == 6 }.size shouldBe 1
+        trace.steps.filter { it.source == "ShowIfOdd.java" && it.line == 3 }.size shouldBe 10
+        trace.steps.filter { it.source == "ShowIfOdd.java" && it.line == 4 }.size shouldBe 5
+    }
+
+    "should trace a simple snippet" {
+        val source = Source.fromSnippet(
+            """System.out.println("Hello");""".trim()
+        )
+        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("Hello")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveSize 1
+        trace.steps[0].line shouldBe 1
+    }
+
+    "should trace a snippet" {
+        val source = Source.fromSnippet(
+            """
+            printWithObject();
+            
+            void printWithObject() {
+              new Printer().print();
+            }
+            
+            class Printer {
+              void print() {
+                System.out.println("Hello");
+              }
+              void unused() {
+                System.out.println("Unused");
+              }
+            }
+            """.trimIndent().trim()
+        )
+        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("Hello")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveAtLeastSize 3
+        trace.steps[0].line shouldBe 1
+        trace.steps.filter { it.line == 4 }.size shouldBe 1
+        trace.steps.filter { it.line == 9 }.size shouldBe 1
+        trace.steps.filter { it.line == 12 }.size shouldBe 0
+    }
+
+    "should trace a Kotlin method" {
+        val result = Source.fromKotlin(
+            """
+            fun main() {
+                println("Hello")
+            }
+            """.trimIndent()
+        ).kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("Hello")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps shouldHaveAtMostSize 2
+        trace.steps[0].line shouldBe 2
+    }
+
+    "should trace a Kotlin forEach loop" {
+        val source = Source.fromKotlin(
+            """
+            fun main() {
+                (1..3).forEach {
+                    println(it * it)
+                }
+            }
+            """.trimIndent()
+        )
+        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("1\n4\n9")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveAtLeastSize 4
+        trace.steps[0].line shouldBe 2
+        trace.steps.filter { it.line == 3 }.size shouldBe 3
+        trace.steps.filter { it.line == 5 }.size shouldBe 1
+        trace.steps.filter { it.line > 5 }.size shouldBe 0
+    }
+
+    "should trace across Kotlin files" {
+        val source = Source(
+            mapOf(
+                "Main.kt" to """
+fun main() {
+  println(test())
+}
+                """.trim(),
+                "Test.kt" to """
+fun test(): List<String> {
+  return listOf("test", "me")
+}
+                """.trim()
+            )
+        )
+        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("[test, me]")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveAtLeastSize 2
+        trace.steps[0] shouldBe LineTraceResult.LineStep("Main.kt", 2)
+        trace.steps[1] shouldBe LineTraceResult.LineStep("Test.kt", 2)
+    }
+
+    "should trace a simple Kotlin snippet" {
+        val source = Source.fromSnippet(
+            """println("Hi")""",
+            SnippetArguments(fileType = Source.FileType.KOTLIN)
+        )
+        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("Hi")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveSize 1
+        trace.steps[0].line shouldBe 1
+    }
+
+    "should trace a Kotlin snippet with a loop" {
+        val source = Source.fromSnippet(
+            """
+                val fruits = listOf("apple", "banana")
+                fruits.forEach {
+                    println(it.uppercase())
+                }
+            """.trimIndent(),
+            SnippetArguments(fileType = Source.FileType.KOTLIN)
+        )
+        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("APPLE\nBANANA")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveAtLeastSize 3
+        trace.steps[0].line shouldBe 1
+        // NOTE: The Kotlin compiler sometimes adds an extra line number entry, double-counting a line
+        trace.steps.filter { it.line == 3 }.size shouldBeGreaterThanOrEqual 2
+        trace.steps.filter { it.line == 4 }.size shouldBe 2
+    }
+
+    "should trace a Kotlin snippet with a method" {
+        val source = Source.fromSnippet(
+            """
+                fun printLoud(text: String) {
+                    println(text.uppercase())
+                }
+                
+                val fruits = listOf("apple", "banana")
+                fruits.forEach(::printLoud)
+            """.trimIndent(),
+            SnippetArguments(fileType = Source.FileType.KOTLIN)
+        )
+        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("APPLE\nBANANA")
+        val trace = result.pluginResult(LineTrace).remap(source)
+        trace.steps shouldHaveAtLeastSize 4
+        trace.steps[0].line shouldBe 5
+        trace.steps.filter { it.line == 2 }.size shouldBeGreaterThanOrEqual 2
+        trace.steps.filter { it.line == 3 }.size shouldBe 2
+        trace.steps.filter { it.line == 4 }.size shouldBe 0
     }
 })

--- a/core/src/test/kotlin/TestLineTrace.kt
+++ b/core/src/test/kotlin/TestLineTrace.kt
@@ -1,0 +1,157 @@
+package edu.illinois.cs.cs125.jeed.core
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.collections.shouldHaveAtMostSize
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class TestLineTrace : StringSpec({
+    "should trace a main method" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    int i = 4;
+    i += 1;
+    System.out.println(i);
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("5")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps shouldHaveAtLeastSize 3
+        trace.steps[0] shouldBe LineTraceResult.LineStep("Main.java", 3)
+    }
+
+    "should trace an if statement" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    int i = 4;
+    if (i > 1) {
+      System.out.println("yes");
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("yes")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps shouldHaveAtLeastSize 3
+        trace.steps.map { it.line } shouldContain 5
+    }
+
+    "should show that an if statement wasn't entered" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    int i = 4;
+    if (i > 9) {
+      System.out.println("yes");
+      System.out.println("the universe has fractured");
+      System.out.println("all is possible");
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps shouldHaveAtMostSize 3
+        trace.steps.map { it.line } shouldNotContain 5
+    }
+
+    "should trace an if-else statement" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    int i = 0;
+    if (i > 1) {
+      System.out.println("yes");
+    } else {
+      System.out.println("no");
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("no")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.map { it.line } shouldNotContain 5
+        trace.steps.map { it.line } shouldContain 7
+    }
+
+    "should trace a for loop" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    for (int i = 0; i < 3; i++) {
+      System.out.println(i);
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("0\n1\n2")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.line == 4 }.size shouldBe 3
+        trace.steps.filter { it.line == 3 }.size shouldBe 4
+    }
+
+    "should trace a while loop" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    int i = 20;
+    while (i > 0) {
+      System.out.println(i);
+      i /= 2;
+      if (i % 2 != 0) {
+        i -= 1;
+      }
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("20\n10\n4\n2")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.line == 5 }.size shouldBe 4
+        trace.steps.filter { it.line == 8 }.size shouldBe 2
+    }
+
+    "should trace multiple functions" {
+        val result = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    for (int i = 0; i < 10; i++) {
+      showIfOdd(i);
+    }
+    System.out.println("Done");
+  }
+  private static void showIfOdd(int i) {
+    if (i % 2 != 0) {
+      System.out.println(i);
+    }
+  }
+}""".trim()
+        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        result should haveCompleted()
+        result should haveOutput("1\n3\n5\n7\n9\nDone")
+        val trace = result.pluginResult(LineTrace)
+        trace.steps.filter { it.line == 4 }.size shouldBe 10
+        trace.steps.filter { it.line == 6 }.size shouldBe 1
+        trace.steps.filter { it.line == 9 }.size shouldBe 10
+        trace.steps.filter { it.line == 10 }.size shouldBe 5
+    }
+})

--- a/core/src/test/kotlin/TestLineTrace.kt
+++ b/core/src/test/kotlin/TestLineTrace.kt
@@ -23,7 +23,7 @@ public class Main {
     System.out.println(i);
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("5")
         val trace = result.pluginResult(LineTrace)
@@ -42,7 +42,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("yes")
         val trace = result.pluginResult(LineTrace)
@@ -63,7 +63,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("")
         val trace = result.pluginResult(LineTrace)
@@ -84,7 +84,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("no")
         val trace = result.pluginResult(LineTrace)
@@ -102,7 +102,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("0\n1\n2")
         val trace = result.pluginResult(LineTrace)
@@ -125,7 +125,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("20\n10\n4\n2")
         val trace = result.pluginResult(LineTrace)
@@ -150,7 +150,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Try\nCatch\nFinally")
         val trace = result.pluginResult(LineTrace)
@@ -176,7 +176,7 @@ public class Main {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("1\n3\n5\n7\n9\nDone")
         val trace = result.pluginResult(LineTrace)
@@ -204,7 +204,7 @@ public class ShowIfOdd {
     }
   }
 }""".trim()
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("1\n3\n5\n7\n9\nDone")
         val trace = result.pluginResult(LineTrace)
@@ -235,7 +235,7 @@ public class ShowIfOdd {
   }
 }""".trim()
             )
-        ).compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("1\n3\n5\n7\n9\nDone")
         val trace = result.pluginResult(LineTrace)
@@ -249,7 +249,7 @@ public class ShowIfOdd {
         val source = Source.fromSnippet(
             """System.out.println("Hello");""".trim()
         )
-        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Hello")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -276,7 +276,7 @@ public class ShowIfOdd {
             }
             """.trimIndent().trim()
         )
-        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Hello")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -299,7 +299,7 @@ public class ShowIfOdd {
                 System.out.println(s); }); // Crazy bracing to ensure only this line is called
             """.trimIndent()
         )
-        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("a\nb\nc")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -317,7 +317,7 @@ public class ShowIfOdd {
             }
             """.trimIndent()
         )
-        val result = source.compile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.compile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveTimedOut()
         val trace = result.pluginResult(LineTrace).remap(source)
         trace.steps[0].line shouldBe 1
@@ -331,7 +331,7 @@ public class ShowIfOdd {
                 println("Hello")
             }
             """.trimIndent()
-        ).kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        ).kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Hello")
         val trace = result.pluginResult(LineTrace)
@@ -349,7 +349,7 @@ public class ShowIfOdd {
             }
             """.trimIndent()
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("1\n4\n9")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -375,7 +375,7 @@ fun test(): List<String> {
                 """.trim()
             )
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("[test, me]")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -389,7 +389,7 @@ fun test(): List<String> {
             """println("Hi")""",
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Hi")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -407,7 +407,7 @@ fun test(): List<String> {
             """.trimIndent(),
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("apple.\nbanana.")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -429,7 +429,7 @@ fun test(): List<String> {
             """.trimIndent(),
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Positive")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -451,7 +451,7 @@ fun test(): List<String> {
             """.trimIndent(),
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("APPLE\nBANANA")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -468,7 +468,7 @@ fun test(): List<String> {
             """.trimIndent(),
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("APPLE\nBANANA")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -487,7 +487,7 @@ fun test(): List<String> {
             """.trimIndent(),
             SnippetArguments(fileType = Source.FileType.KOTLIN)
         )
-        val result = source.kompile().execute(SourceExecutionArguments(plugins = listOf(LineTrace)))
+        val result = source.kompile().execute(SourceExecutionArguments().addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("APPLE\nBANANA")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -516,7 +516,7 @@ try {
 }
         """.trim()
         )
-        val result = source.compile().execute(SourceExecutionArguments(maxExtraThreads = 1, plugins = listOf(LineTrace)))
+        val result = source.compile().execute(SourceExecutionArguments(maxExtraThreads = 1).addPlugin(LineTrace))
         result should haveCompleted()
         result should haveOutput("Started\nEnded")
         val trace = result.pluginResult(LineTrace).remap(source)
@@ -543,7 +543,7 @@ try {
             }
             """.trimIndent()
         )
-        val executionArgs = SourceExecutionArguments(waitForShutdown = true, timeout = 2000, plugins = listOf(LineTrace))
+        val executionArgs = SourceExecutionArguments(waitForShutdown = true, timeout = 2000).addPlugin(LineTrace)
         val result = source.kompile().execute(executionArgs)
         result should haveCompleted()
         result should haveOutput("Started\nFinished")

--- a/core/src/test/kotlin/TestSnippet.kt
+++ b/core/src/test/kotlin/TestSnippet.kt
@@ -518,7 +518,8 @@ class Tester implements Test {
             """
 class Test<T>
 fun <T> Test<T>.requireIndexIsNotNegative(index: Int): Unit = require(index >= 0)
-            """.trim(), SnippetArguments(fileType = Source.FileType.KOTLIN)
+            """.trim(),
+            SnippetArguments(fileType = Source.FileType.KOTLIN)
         ).kompile()
     }
     "should allow anonymous classes in snippets" {

--- a/core/src/test/kotlin/TestSnippet.kt
+++ b/core/src/test/kotlin/TestSnippet.kt
@@ -298,6 +298,14 @@ System.out.println(countArray(array, new IncludeValue() {
         """.trim()
         ).compile()
     }
+    "should handle warnings from outside the snippet" {
+        Source.fromSnippet(
+            """
+import net.bytebuddy.agent.ByteBuddyAgent;
+ByteBuddyAgent.install(ByteBuddyAgent.AttachmentProvider.ForEmulatedAttachment.INSTANCE);
+        """.trim()
+        ).compile()
+    }
     "should parse kotlin snippets" {
         Source.fromSnippet(
             """

--- a/core/src/test/kotlin/sandbox/TestPermissions.kt
+++ b/core/src/test/kotlin/sandbox/TestPermissions.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.types.instanceOf
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.lang.IllegalArgumentException
@@ -473,5 +474,19 @@ try {
         """.trim()
         ).compile().execute(SourceExecutionArguments(timeout = 10000))
         executionResult.permissionDenied shouldBe true
+    }
+    "should not allow calling forbidden methods" {
+        val executionResult = Source.fromSnippet(
+            """
+import java.lang.invoke.MethodHandles;
+
+MethodHandles.Lookup lookup = null;
+var clazz = lookup.findClass("edu.illinois.cs.cs125.jeed.core.Sandbox");
+System.out.println(clazz);
+        """.trim()
+        ).compile().execute(SourceExecutionArguments(timeout = 10000))
+        executionResult.permissionDenied shouldBe true
+        executionResult.threw shouldBe instanceOf<SecurityException>()
+        executionResult.threw!!.message shouldBe "invocation of forbidden method"
     }
 })

--- a/core/src/test/kotlin/sandbox/TestPermissions.kt
+++ b/core/src/test/kotlin/sandbox/TestPermissions.kt
@@ -586,4 +586,19 @@ System.out.println(cons.newInstance());
         executionResult.permissionDenied shouldBe true
         executionResult.completed shouldBe false
     }
+    "should not allow loading sun.misc classes" {
+        val executionResult = Source.fromSnippet(
+            """
+import sun.misc.Unsafe;
+
+Unsafe unsafe = null;
+unsafe.getInt(null, 0); // obvious NPE, but should fail in classloading first
+        """.trim()
+        ).compile().execute(SourceExecutionArguments(timeout = 10000))
+        executionResult.permissionDenied shouldBe true
+        executionResult.permissionRequests.find {
+            it.permission.name.startsWith("accessClassInPackage.sun")
+        } shouldNot beNull()
+        executionResult.completed shouldBe false
+    }
 })

--- a/core/src/test/kotlin/sandbox/TestResourceExhaustion.kt
+++ b/core/src/test/kotlin/sandbox/TestResourceExhaustion.kt
@@ -682,4 +682,44 @@ countedLoop(1000000);
         executionResult shouldNot haveCompleted()
         executionResult should haveOutput("Warmed up")
     }
+    "should terminate a console-scanning thread" {
+        val compileResult = Source(
+            mapOf(
+                "Main.java" to """
+import java.util.Scanner;
+public class Main {
+    public static void main() {
+        var scanner = new Scanner(System.in);
+        scanner.nextLine();
+    }
+}""".trim()
+            )
+        ).compile()
+
+        (1..8).forEach { _ ->
+            val executionResult = compileResult.execute()
+            executionResult shouldNot haveCompleted()
+        }
+    }
+    "should terminate a console-reading thread" {
+        val compileResult = Source(
+            mapOf(
+                "Main.java" to """
+public class Main {
+    public static void main() throws Exception {
+        while (true) {
+            int b = -1;
+            while ((b = System.in.read()) < 0) {}
+            System.out.println(b);
+        }
+    }
+}""".trim()
+            )
+        ).compile()
+
+        (1..8).forEach { _ ->
+            val executionResult = compileResult.execute()
+            executionResult shouldNot haveCompleted()
+        }
+    }
 })


### PR DESCRIPTION
This adds a sandbox plugin API used for line tracing/counting and Jacoco coverage. See [`TestLineTrace.kt`](https://github.com/Fleex255/jeed/blob/ef8a86ad08048abd9558c08e6634db4fcb6417bd/core/src/test/kotlin/TestLineTrace.kt) for usage examples.

The sandbox security was also tightened in a few places. The one place we weren't sure about was the whitelisting of `Constructor` for coroutines to work (removed in https://github.com/cs125-illinois/jeed/commit/9e17be8c21b508e5afe95899aa0b8f8409b3513d). If this causes problems on non-Windows platforms, that commit can be reverted and https://github.com/cs125-illinois/jeed/commit/19a5607859dc6a9e66e309d85c7816bb91df1f26 will narrow the hole through a different mechanism.