### PR TITLE
Class initialization defense/investigation

### DIFF
--- a/core/src/main/kotlin/Jacoco.kt
+++ b/core/src/main/kotlin/Jacoco.kt
@@ -15,7 +15,11 @@ import org.objectweb.asm.Opcodes
 object Jacoco : SandboxPlugin<Unit, CoverageBuilder> {
     private val instrumenter = Instrumenter(IsolatedJacocoRuntime)
 
-    override fun createInstrumentationData(arguments: Unit): Any {
+    override fun createInstrumentationData(
+        arguments: Unit,
+        classLoaderConfiguration: Sandbox.ClassLoaderConfiguration,
+        allPlugins: List<ConfiguredSandboxPlugin<*, *>>
+    ): Any {
         return JacocoInstrumentationData()
     }
 

--- a/core/src/main/kotlin/PlatformWarm.kt
+++ b/core/src/main/kotlin/PlatformWarm.kt
@@ -1,0 +1,27 @@
+package edu.illinois.cs.cs125.jeed.core
+
+import java.lang.invoke.LambdaMetafactory
+import java.lang.invoke.StringConcatFactory
+import java.lang.runtime.ObjectMethods
+
+/*
+ * Static members in libraries are a challenge for confined task isolation. Third-party libraries can be reloaded,
+ * but JDK (platform) classes cannot. It is important that classes with JVM-wide state are initialized outside the
+ * sandbox; if they are initialized by a confined task, they may hold references to that task or be interrupted
+ * in the middle of their initialization, thereby ruining the class for the entire JVM. This method, called before
+ * any confined tasks are started, initializes important shared platform classes.
+ */
+internal fun warmPlatform() {
+    // Records are supported by a bootstrap method on ObjectMethods
+    ensureInitialized(ObjectMethods::class.java)
+
+    // Lambdas by LambdaMetafactory (very likely already initialized by the JVM, but it doesn't hurt to make sure)
+    ensureInitialized(LambdaMetafactory::class.java)
+
+    // Some string concatenation by StringConcatFactory (again likely already initialized)
+    ensureInitialized(StringConcatFactory::class.java)
+}
+
+private fun ensureInitialized(klass: Class<*>) {
+    Class.forName(klass.name)
+}

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -694,7 +694,7 @@ object Sandbox {
         internal val pluginInstrumentationData = configuredPlugins.map {
             @Suppress("UNCHECKED_CAST")
             it as ConfiguredSandboxPlugin<Any, Any>
-            it.plugin to it.plugin.createInstrumentationData(it.arguments)
+            it.plugin to it.plugin.createInstrumentationData(it.arguments, classLoaderConfiguration, configuredPlugins)
         } // Intentionally not toMap'd so that order is preserved
 
         override val definedClasses: Set<String> get() = knownClasses.keys.toSet()
@@ -1768,7 +1768,12 @@ interface SandboxPlugin<A : Any, V : Any> {
     val id: String
         get() = javaClass.simpleName.decapitalizeAsciiOnly()
 
-    fun createInstrumentationData(arguments: A): Any? = null
+    fun createInstrumentationData(
+        arguments: A,
+        classLoaderConfiguration: Sandbox.ClassLoaderConfiguration,
+        allPlugins: List<ConfiguredSandboxPlugin<*, *>>
+    ): Any? = null
+
     fun transformBeforeSandbox(
         bytecode: ByteArray,
         name: String,

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -49,6 +49,10 @@ import kotlin.reflect.jvm.javaMethod
 private typealias SandboxCallableArguments<T> = (Pair<ClassLoader, (() -> Any?) -> JeedOutputCapture>) -> T
 
 object Sandbox {
+    init {
+        warmPlatform()
+    }
+
     @JsonClass(generateAdapter = true)
     class ClassLoaderConfiguration(
         val whitelistedClasses: Set<String> = DEFAULT_WHITELISTED_CLASSES,

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -598,10 +598,10 @@ object Sandbox {
             existingActiveThreads.filter { !stoppedThreads.contains(it) }.forEach {
                 // TEMP: Report any platform classes the thread is currently initializing
                 if (existingActiveThreads.size == 1) { // Slow!
-                    @Suppress("DEPRECATION") it.suspend()
                     runCatching {
                         it.stackTrace.filterNotNull().filter { frame ->
-                            frame.moduleName?.startsWith("java.") == true && frame.methodName == "<clinit>"
+                            (frame.classLoaderName != null || frame.className.contains(".")) &&
+                                frame.methodName == "<clinit>"
                         }.forEach { frame ->
                             confinedTask.killedClassInitializers.add(frame.className)
                         }

--- a/core/src/main/kotlin/Sandbox.kt
+++ b/core/src/main/kotlin/Sandbox.kt
@@ -691,6 +691,14 @@ object Sandbox {
             klass
         }.toSet()
 
+        init {
+            val plugins = configuredPlugins.map { it.plugin }
+            plugins.forEachIndexed { index, plugin ->
+                if (plugins.lastIndexOf(plugin) > index) {
+                    error("Duplicate plugin: $plugin")
+                }
+            }
+        }
         internal val pluginInstrumentationData = configuredPlugins.map {
             @Suppress("UNCHECKED_CAST")
             it as ConfiguredSandboxPlugin<Any, Any>

--- a/core/src/test/kotlin/TestLineTrace.kt
+++ b/core/src/test/kotlin/TestLineTrace.kt
@@ -18,7 +18,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.endWith
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.types.beInstanceOf
+import org.junit.jupiter.api.assertThrows
 import java.lang.reflect.InvocationTargetException
 
 class TestLineTrace : StringSpec({
@@ -842,5 +844,19 @@ public class Main {
         trace.steps[0].line shouldBe 12
         trace.steps.map { it.line } shouldContain 7
         trace.steps.map { it.line } shouldNotContain 4
+    }
+
+    "should not be installable as a duplicate" {
+        val source = Source.fromJava(
+            """
+public class Main {
+  public static void main() {
+    System.out.println("Done");
+  }
+}""".trim()
+        )
+        assertThrows<IllegalStateException> {
+            source.compile().execute(SourceExecutionArguments().addPlugin(LineTrace).addPlugin(LineTrace))
+        }.message shouldStartWith "Duplicate plugin: edu.illinois.cs.cs125.jeed.core.LineTrace"
     }
 })

--- a/core/src/test/kotlin/sandbox/TestPermissions.kt
+++ b/core/src/test/kotlin/sandbox/TestPermissions.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.instanceOf
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.PrintStream
 import java.lang.IllegalArgumentException
 import java.util.PropertyPermission
@@ -390,6 +391,14 @@ Map confinedTasks = (Map) field.get(null);
         }
 
         executionResult should haveCompleted()
+    }
+    "should not prevent trusted code from accessing files" {
+        val executionResult = Sandbox.execute {
+            File("test.txt").exists()
+        }
+
+        executionResult should haveCompleted()
+        executionResult.permissionDenied shouldBe false
     }
     "should not allow static{} to escape the sandbox" {
         val executionResult = Source(

--- a/core/src/test/kotlin/sandbox/TestResourceExhaustion.kt
+++ b/core/src/test/kotlin/sandbox/TestResourceExhaustion.kt
@@ -750,4 +750,23 @@ public class Main {
             executionResult shouldNot haveCompleted()
         }
     }
+    "should terminate a runaway static initializer" {
+        val executionResult = Source(
+            mapOf(
+                "Main.java" to """
+public class Main {
+    static {
+        while ("".hashCode() != 124) {}
+    }
+    public static void main() {
+        System.out.println("Main");
+    }
+}
+        """.trim()
+            )
+        ).compile().execute()
+
+        executionResult shouldNot haveCompleted()
+        executionResult should haveTimedOut()
+    }
 })


### PR DESCRIPTION
This ensures certain bootstrap method owners are initialized outside the sandbox so thread death can't ruin them. Shutdown of single-thread tasks now (temporarily) checks if a class initializer is going to be killed. 

For defense-in-depth and to possibly hamper attempts to intentionally ruin class initializers, direct use of classloader-related methods is now banned. If this causes a problem on non-Windows systems, https://github.com/cs125-illinois/jeed/commit/03e1d286e312cf9c576c9fcec204e36fa6ec561f can be reverted with no ill effects.

Other changes include sanity checks on the plugin user API.